### PR TITLE
Admin invoice index show

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,10 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'faraday', '~> 0.9.2'
+
+gem 'json', '~> 1.8', '>= 1.8.3'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'pry'

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -1,0 +1,5 @@
+class Admin::InvoicesController < ApplicationController
+  def index
+    @invoices = Invoice.all
+  end
+end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -2,4 +2,8 @@ class Admin::InvoicesController < ApplicationController
   def index
     @invoices = Invoice.all
   end
+
+  def show
+    @invoice = Invoice.find(params[:id])
+  end 
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -18,6 +18,10 @@ class Invoice < ApplicationRecord
     end
   end
 
+  def created_at_view_format
+    created_at.strftime('%A, %B %d, %Y')
+  end
+
   def self.all_invoices_with_unshipped_items
     joins(:invoice_items).where('invoice_items.status = ?', 1).distinct(:id).order(:created_at)
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -10,6 +10,14 @@ class Invoice < ApplicationRecord
     where(customer_id: customer_id)
   end
 
+  def status_view_format
+    if status == "in_progress"
+      "In Progress"
+    else
+      status.capitalize
+    end
+  end
+
   def self.all_invoices_with_unshipped_items
     joins(:invoice_items).where('invoice_items.status = ?', 1).distinct(:id).order(:created_at)
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -11,11 +11,7 @@ class Invoice < ApplicationRecord
   end
 
   def status_view_format
-    if status == "in_progress"
-      "In Progress"
-    else
-      status.capitalize
-    end
+    status.titleize
   end
 
   def created_at_view_format

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,15 +1,11 @@
 <h1>Admin Dashboard</h1>
 
 <section class="navigation" id="merchants">
-  <%= form_with url: "/admin/merchants", method: :get do |form| %>
-    <%= form.submit "Merchants" %>
-  <% end %>
+  <%= link_to("Merchants", admin_merchants_path) %>
 </section>
 
 <section class="navigation" id="invoices">
-  <%= form_with url: "/admin/invoices", method: :get do |form| %>
-    <%= form.submit "Invoices" %>
-  <% end %>
+  <%= link_to("Invoices", admin_invoices_path) %>
 </section>
 
 <section class="top_customers">

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -20,7 +20,7 @@
 <section class="incomplete_invoices">
   <h2>Incomplete Invoices</h2>
     <% @incomplete_invoices.each do |incomplete_invoice| %>
-      Invoice #<a href="/admin/invoices/<%= incomplete_invoice.id %>"><%= incomplete_invoice.id %></a>- <%= incomplete_invoice.created_at.strftime('%A, %B %d, %Y') %>
+      Invoice #<a href="/admin/invoices/<%= incomplete_invoice.id %>"><%= incomplete_invoice.id %></a>- <%= incomplete_invoice.created_at_view_format %>
       <br>
     <% end %>
 </section>

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -3,5 +3,6 @@
 <section id='all-invoices'>
   <% @invoices.each do |invoice| %>
     <%= link_to(invoice.id, admin_invoice_path(invoice.id)) %>
+    <br>
   <% end %>
 </section>

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -1,0 +1,7 @@
+<h1>Admin Invoices Index</h1>
+
+<section id='all-invoices'>
+  <% @invoices.each do |invoice| %>
+    <%= invoice.id %>
+  <% end %>
+</section>

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -2,6 +2,6 @@
 
 <section id='all-invoices'>
   <% @invoices.each do |invoice| %>
-    <%= invoice.id %>
+    <%= link_to(invoice.id, admin_invoice_path(invoice.id)) %>
   <% end %>
 </section>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,0 +1,6 @@
+<h1>Invoice # <%= @invoice.id %> - Admin Show Page</h1>
+
+<section id='invoice_info'>
+  <p>Status: <%= @invoice.status_view_format %></p>
+  <p>Date Created: <%= @invoice.created_at_view_format %></p>
+</section>

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -84,13 +84,12 @@ RSpec.describe "Admin Dashboard" do
     it "should have links to the Admin merchant and invoice index" do
       visit admin_index_path
 
-      click_button("Merchants")
+      click_link("Merchants")
       expect(current_path).to eq("/admin/merchants")
       visit admin_index_path
 
-      # click_button("Invoices")
-      # expect(current_path).to eq("/admin/invoices")
-
+      click_link("Invoices")
+      expect(current_path).to eq("/admin/invoices")
     end
   end
   describe "overall admin level statistics" do

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe 'Admin invoices index spec' do
         expect(page).to have_link(@invoice2.id)
         expect(page).to have_link(@invoice3.id)
 
-        # Only testing one invoice
         click_link @invoice1.id
         expect(current_path).to eq admin_invoice_path(@invoice1)
       end

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin invoices index spec' do
+  before :each do
+    @invoice1, @invoice2, @invoice3 = create_list(:invoice, 3)
+  end
+
+  describe 'as an admin' do
+    it 'shows id# of each invoice in the system' do
+      visit admin_invoices_path
+
+      within('#all-invoices') do
+        expect(page).to have_content(@invoice1.id)
+        expect(page).to have_content(@invoice2.id)
+        expect(page).to have_content(@invoice3.id)
+      end
+    end
+
+    it 'ids of invoices are links to their show page' do
+      visit admin_invoices_path
+
+      within('#all-invoices') do
+        expect(page).to have_link(@invoice1.id)
+        expect(page).to have_link(@invoice2.id)
+        expect(page).to have_link(@invoice3.id)
+
+        # Only testing one invoice
+        click_link @invoice1.id
+        expect(current_path).to eq admin_invoice_path(@invoice1)
+      end
+    end
+  end
+end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin invoices show page' do
+  before :each do
+    @invoice_1 = create(:invoice)
+  end
+
+  describe 'as an admin' do
+    describe'displays invoice information' do
+      it 'like id, status, created_at in Day, Month DD, YYYY' do
+        visit admin_invoice_path(@invoice_1)
+
+
+        expect(page).to have_content(@invoice_1.id)
+        expect(page).to have_content(@invoice_1.status)
+        expect(page).to have_content(@invoice_1.created_at.strftime('%A, %B %d, %Y'))
+      end
+    end
+  end
+end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Admin invoices show page' do
 
 
         expect(page).to have_content(@invoice_1.id)
-        expect(page).to have_content(@invoice_1.status)
+        expect(page).to have_content(@invoice_1.status_view_format)
         expect(page).to have_content(@invoice_1.created_at.strftime('%A, %B %d, %Y'))
       end
     end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -37,6 +37,27 @@ RSpec.describe Invoice do
 
   end
 
+  describe 'instance methods' do
+    describe '#status_view_format' do
+      it "cleans up statuses so they are capitalize and have no symbols on view" do
+        invoice_a = create(:invoice, status: Invoice.statuses[:cancelled])
+        invoice_b = create(:invoice, status: Invoice.statuses[:completed])
+        invoice_c = create(:invoice, status: Invoice.statuses[:in_progress])
+
+        expect(invoice_a.status_view_format).to eq("Cancelled")
+        expect(invoice_b.status_view_format).to eq("Completed")
+        expect(invoice_c.status_view_format).to eq("In Progress")
+      end
+    end
+    describe '#created_at_view_format' do
+      it "cleans up statuses so they are capitalize and have no symbols on view" do
+        invoice_a = create(:invoice, created_at: Time.new(2021, 2, 24))
+
+        expect(invoice_a.created_at_view_format).to eq("Wednesday, February 24, 2021")
+      end
+    end
+  end
+
   describe 'class methods' do
     describe '::find_from(customer_id)' do
       it 'returns invoices that belong to a specific customer' do


### PR DESCRIPTION
**What Changed**
- Create data and status formatting methods on Invoice model for view page use
- Create link_to on Admin Dashboard to navigate to "admin/merchants" and "admin/invoices"
- Create Admin Invoices Index Page
- Create Admin Invoices Show Page

**Next Steps**
- Continue with invoice user stories, add customer information to show page
- Potential refactor with the formatting methods if other models need similar display

**Known Issues**

